### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -6,7 +6,7 @@ entries:
     created: "2020-10-27T15:15:48.591426873Z"
     dependencies:
     - name: fluent-logshipping-app
-      repository: https://giantswarm.github.com/giantswarm-playground-catalog
+      repository: https://giantswarm.github.io/giantswarm-playground-catalog
       version: 0.5.2
     description: A Helm Chart for Workspace Analytics Solution for Azure.
     digest: ed2fbaf104ff60e0bd6d4d5f87d7fd7b541a7ee3c4b66c1474120589948baa3d
@@ -18,7 +18,7 @@ entries:
     - https://github.com/giantswarm/fluent-logshipping-app
     - https://github.com/giantswarm/azure-tools-operator
     urls:
-    - https://giantswarm.github.com/giantswarm-azure-catalog/azure-logs-workspace-app-0.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-azure-catalog/azure-logs-workspace-app-0.0.1.tgz
     version: 0.0.1
   - apiVersion: v1
     appVersion: v0.0.1
@@ -33,6 +33,6 @@ entries:
     - https://github.com/giantswarm/fluent-logshipping-app/
     - https://github.com/giantswarm/azure-tools-operator
     urls:
-    - https://giantswarm.github.com/giantswarm-azure-catalog/azure-logs-workspace-app-0.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-azure-catalog/azure-logs-workspace-app-0.0.0.tgz
     version: 0.0.0
 generated: "2020-10-27T15:15:48.588923715Z"


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898